### PR TITLE
[G-API] Wrap cv::gapi::infer into python

### DIFF
--- a/modules/gapi/include/opencv2/gapi/infer.hpp
+++ b/modules/gapi/include/opencv2/gapi/infer.hpp
@@ -133,10 +133,12 @@ struct InOutInfo
  * @{
  * @brief G-API object used to collect network inputs
  */
-class GAPI_EXPORTS GInferInputs
+class GAPI_EXPORTS_W_SIMPLE GInferInputs
 {
 public:
+    GAPI_WRAP GInferInputs() = default;
     cv::GMat operator[](const std::string& name);
+    GAPI_WRAP void setInput(const String& name, const cv::GMat& value) { in_blobs.emplace(name, value); }
     const std::unordered_map<std::string, cv::GMat>& getBlobs() const;
 
 private:
@@ -148,11 +150,12 @@ private:
  * @{
  * @brief G-API object used to collect network outputs
  */
-struct GAPI_EXPORTS GInferOutputs
+struct GAPI_EXPORTS_W_SIMPLE GInferOutputs
 {
 public:
+    GAPI_WRAP GInferOutputs() = default;
     GInferOutputs(std::shared_ptr<cv::GCall> call);
-    cv::GMat at(const std::string& name);
+    GAPI_WRAP cv::GMat at(const String& name);
 
 private:
     std::shared_ptr<cv::GCall> m_call;
@@ -333,6 +336,11 @@ infer(const std::string& tag, const GInferInputs& inputs)
     return GInferOutputs{std::move(call)};
 }
 
+GAPI_EXPORTS_W inline GInferOutputs infer(const String& name, const GInferInputs& inputs)
+{
+    return infer<Generic>(name, inputs);
+}
+
 } // namespace gapi
 } // namespace cv
 
@@ -361,8 +369,8 @@ struct GAPI_EXPORTS GNetParam {
  *
  * @sa cv::gapi::networks
  */
-struct GAPI_EXPORTS GNetPackage {
-    GNetPackage() : GNetPackage({}) {}
+struct GAPI_EXPORTS_W_SIMPLE GNetPackage {
+    GAPI_WRAP GNetPackage() : GNetPackage({}) {}
     explicit GNetPackage(std::initializer_list<GNetParam> &&ii);
     std::vector<GBackend> backends() const;
     std::vector<GNetParam> networks;

--- a/modules/gapi/include/opencv2/gapi/infer/ie.hpp
+++ b/modules/gapi/include/opencv2/gapi/infer/ie.hpp
@@ -122,6 +122,7 @@ protected:
 template<>
 class Params<cv::gapi::Generic> {
 public:
+    Params() = default;
     Params(const std::string& tag,
            const std::string &model,
            const std::string &weights,
@@ -139,6 +140,16 @@ protected:
     detail::ParamDesc desc;
     std::string m_tag;
 };
+
+// NB: For python bindings
+using GenParams = Params<Generic>;
+GAPI_EXPORTS_W inline GenParams params(const String& tag,
+                                       const String& model,
+                                       const String& weights,
+                                       const String& device)
+{
+    return GenParams(tag, model, weights, device);
+}
 
 } // namespace ie
 } // namespace gapi

--- a/modules/gapi/misc/python/pyopencv_gapi.hpp
+++ b/modules/gapi/misc/python/pyopencv_gapi.hpp
@@ -4,6 +4,8 @@
 #ifdef HAVE_OPENCV_GAPI
 
 using gapi_GKernelPackage = cv::gapi::GKernelPackage;
+using gapi_GNetPackage = cv::gapi::GNetPackage;
+using gapi_ie_GenParams = cv::gapi::ie::GenParams;
 
 template<>
 bool pyopencv_to(PyObject* obj, std::vector<GCompileArg>& value, const ArgInfo& info)

--- a/modules/gapi/misc/python/shadow_gapi.hpp
+++ b/modules/gapi/misc/python/shadow_gapi.hpp
@@ -4,6 +4,7 @@
 namespace cv
 {
    GAPI_EXPORTS_W GCompileArgs compile_args(gapi::GKernelPackage pkg);
+   GAPI_EXPORTS_W GCompileArgs compile_args(gapi::GNetPackage pkg);
 
    class GAPI_EXPORTS_W_SIMPLE GProtoArg { };
    class GAPI_EXPORTS_W_SIMPLE GProtoInputArgs { };
@@ -12,4 +13,14 @@ namespace cv
 
    using GProtoInputArgs  = GIOProtoArgs<In_Tag>;
    using GProtoOutputArgs = GIOProtoArgs<Out_Tag>;
-} // namespace cv
+
+   namespace gapi
+   {
+       GAPI_EXPORTS_W gapi::GNetPackage networks(cv::gapi::ie::GenParams params);
+
+       namespace ie
+       {
+           class GAPI_EXPORTS_W_SIMPLE GenParams { };
+       }  // namespace ie
+   }  // namespace gapi
+}  // namespace cv


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

## API example
``` 
img = cv.imread('img.png')
g_in = cv.GMat()
inputs = cv.GInferInputs()
inputs.setInput('data', g_in)

outputs = cv.gapi.infer('age-gender', inputs)

age_g = outputs.at('age_conv3')
gender_g = outputs.at('prob')

comp = cv.GComputation(cv.GIn(g_in), cv.GOut(age_g, gender_g))
pp = cv.gapi.ie.params('age-gender', '*.bin', '*.xml', 'CPU')

age, gender = comp.apply(cv.gin(img), args=cv.compile_args(cv.gapi.network(pp)))                                                                                                                                                                                                                                                                                                                                                                                                                                              
```

<!-- Please describe what your pullrequest is changing -->
